### PR TITLE
Modify app to use an environment variable for the token

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ cd Snappify
 npm install
 ```
 
+- Get your own API token from [Screenshot API](https://screenshotapi.net/) and insert it inside `.env` under the variable name `REACT_APP_API_TOKEN`.
+``` bash
+echo REACT_APP_API_TOKEN=your-token-here > .env
+```
+
 - Run Server
 
 ```

--- a/src/services/screenshot.jsx
+++ b/src/services/screenshot.jsx
@@ -7,7 +7,7 @@ const getScreenshot = (link, w, h, setSc) => {
 	  , {
       params: {
         url: link,
-        token: 'REUXZIEP5RLXUEFS8PEF0RZTH15SJK5A',
+        token: process.env.REACT_APP_API_TOKEN,
         width: w,
         height: h,
         lazy_load: true,


### PR DESCRIPTION
# Modify app to use an environment variable for the token

### What is the change?
- Modified `src/services/screenshot.jsx` retrieve the API token from an environment variable instead of using a hardcoded value.
  ``` jsx
    ...
    url: link,
    token: process.env.REACT_APP_API_TOKEN,
    width: w,
    ...
  ```
- Modified `README.md` to include the environment setup with the API token.
  ```` md
  ...
  npm install
  ```
  
  - Get your own API token from [Screenshot API](https://screenshotapi.net/) and insert it inside `.env` under the variable name   `REACT_APP_API_TOKEN`.
  ``` bash
  echo REACT_APP_API_TOKEN=your-token-here > .env
  ```
  
  - Run Server
  ...
  ````

### Which issue does this resolve?
Fixes: #21: **Store API token as an environment variable**

### How was it tested?
By inserting a token inside a `.env` file inside the repository folder.
``` env
REACT_APP_API_TOKEN=your-token-here
```

### Why such a long name for the environment variable?
That is because value of every environment variable prefixed `REACT_APP_` will be included in the final build.

## Submissions guide:
- [x] Have you followed the [Contribution guide](https://github.com/PragatiVerma18/Snappify/blob/master/CONTRIBUTING.md)?
- [x] Have you made corresponding changes to the documentation?
- [x] Your submission doesn't break any existing feature.
- [x] Have you lint your code locally prior to submission?