### PR TITLE
feat: Added GitHub action to auto-assign mentors

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,7 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+# Set to true to add assignees to pull requests
+addAssignees: false
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers:
+  - sansyrox

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -4,4 +4,5 @@ addReviewers: true
 addAssignees: false
 # A list of reviewers to be added to pull requests (GitHub user name)
 reviewers:
-  - sansyrox
+  - PragatiVerma18
+  

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,0 +1,7 @@
+name: 'Auto Assign'
+on: pull_request
+jobs:
+  add-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v1.1.2

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -5,3 +5,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: kentaro-m/auto-assign-action@v1.1.2
+        


### PR DESCRIPTION
Fixes: #38 

### What is the change?
Added a GitHub action to auto assign mentors for every pr.

### How was it tested?
I have tested the GitHub action in my personal repository. It automatically adds me as a reviewer on every pr created. Here is a link to the repo:
https://github.com/m-code12/Test_repo

## Submissions guide:

- [ ] Have you made corresponding changes to the documentation?
- [x] Your submission doesn't break any existing feature.
- [ ] Have you lint your code locally prior to submission?
